### PR TITLE
[Fixes #7]Fix the way we cleanup the logs

### DIFF
--- a/scripts/cleanup_cfme.sh
+++ b/scripts/cleanup_cfme.sh
@@ -22,8 +22,7 @@ rm -rf /run/httpd/*
 
 mkdir -p ~/evm_logs/"$start"
 mv /var/www/miq/vmdb/log/evm.log* ~/evm_logs/"$start"/
-rm -rf /var/www/miq/vmdb/log/*.log*
-rm -rf /var/www/miq/vmdb/log/apache/*.log*
+find /var/www/miq/vmdb/log/ -type f -name "*.log" -exec truncate -s 0
 
 # miqtop miqvmstat
 systemctl start httpd evmserverd collectd


### PR DESCRIPTION
The PR fixes #7 related to the failures being logged by collectd
after the cleanup activity is performed. Utilizing truncate instead
of removing the files, fixes up the issues for us.

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>